### PR TITLE
Fix undefined variable in analytics

### DIFF
--- a/ai-chatbot-pro/admin/analytics-page.php
+++ b/ai-chatbot-pro/admin/analytics-page.php
@@ -22,6 +22,8 @@ add_action('admin_menu', 'aicp_add_analytics_page');
 function aicp_render_analytics_page() {
     global $wpdb;
     $logs_table = $wpdb->prefix . 'aicp_chat_logs';
+
+    $assistant_id = isset($_GET['post']) ? intval($_GET['post']) : 0;
     $stats = class_exists('AICP_Lead_Manager') ? AICP_Lead_Manager::get_lead_stats($assistant_id) : [];
     $total_conversations = $wpdb->get_var("SELECT COUNT(DISTINCT session_id) FROM $logs_table");
     $total_leads = $wpdb->get_var("SELECT COUNT(*) FROM $logs_table WHERE has_lead = 1");


### PR DESCRIPTION
## Summary
- grab assistant id safely before fetching lead stats
- use new variable in `aicp_render_analytics_page`

## Testing
- `php -l ai-chatbot-pro/admin/analytics-page.php`
- `php -l ai-chatbot-pro/includes/class-lead-manager.php`


------
https://chatgpt.com/codex/tasks/task_e_687bd3b8446c83309805caaf387e997f