### PR TITLE
Add basic WP PHPUnit test setup

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,0 +1,6 @@
+{
+    "name": "ai-chatbot-pro/ai-chatbot",
+    "require-dev": {
+        "wp-phpunit/wp-phpunit": "^6"
+    }
+}

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,9 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit bootstrap="tests/bootstrap.php"
+         colors="true">
+    <testsuites>
+        <testsuite name="Plugin Test Suite">
+            <directory>tests/</directory>
+        </testsuite>
+    </testsuites>
+</phpunit>

--- a/tests/bootstrap.php
+++ b/tests/bootstrap.php
@@ -1,0 +1,15 @@
+<?php
+$_tests_dir = getenv('WP_TESTS_DIR');
+if ( ! $_tests_dir ) {
+    $_tests_dir = rtrim( sys_get_temp_dir(), '/\' ) . '/wordpress-tests-lib';
+}
+
+require_once $_tests_dir . '/includes/functions.php';
+
+function _manually_load_plugin() {
+    require dirname( __DIR__ ) . '/ai-chatbot-pro/ai-chatbot-pro.php';
+}
+
+tests_add_filter( 'muplugins_loaded', '_manually_load_plugin' );
+
+require $_tests_dir . '/includes/bootstrap.php';

--- a/tests/test-lead-manager.php
+++ b/tests/test-lead-manager.php
@@ -1,0 +1,20 @@
+<?php
+class Lead_Manager_Test extends WP_UnitTestCase {
+    public function test_detect_contact_data_complete_conversation() {
+        $conversation = [
+            ['role' => 'user', 'content' => 'Hola, me llamo Juan Pérez.'],
+            ['role' => 'assistant', 'content' => 'Encantado de conocerte, Juan.'],
+            ['role' => 'user', 'content' => 'Mi email es juan@example.com y mi teléfono es 912 345 678. Mi web es juanperez.com.'],
+        ];
+
+        $result = AICP_Lead_Manager::detect_contact_data( $conversation );
+
+        $this->assertTrue( $result['has_lead'] );
+        $this->assertTrue( $result['is_complete'] );
+        $this->assertEquals( 'Juan Pérez', $result['data']['name'] );
+        $this->assertEquals( 'juan@example.com', $result['data']['email'] );
+        $this->assertEquals( 'http://juanperez.com', $result['data']['website'] );
+        $this->assertArrayHasKey( 'phone', $result['data'] );
+        $this->assertEmpty( $result['missing_fields'] );
+    }
+}


### PR DESCRIPTION
## Summary
- configure PHPUnit for WordPress with `wp-phpunit`
- add test bootstrap
- add example test for `AICP_Lead_Manager::detect_contact_data`

## Testing
- `phpunit -c phpunit.xml tests/test-lead-manager.php` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bd3d2f75883309ca2e4d18db677ae