### PR TITLE
Fix send icon SVG namespace

### DIFF
--- a/ai-chatbot-pro/assets/js/chatbot.js
+++ b/ai-chatbot-pro/assets/js/chatbot.js
@@ -30,7 +30,7 @@ jQuery(function($) {
     // --- HTML y UI ---
     function buildChatHTML() {
         const closeIcon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M19 6.41L17.59 5 12 10.59 6.41 5 5 6.41 10.59 12 5 17.59 6.41 19 12 13.41 17.59 19 19 17.59 13.41 12z"/></svg>`;
-        const sendIcon = `<svg xmlns="http://www.w3.org/2000/24 24" viewBox="0 0 24 24" fill="currentColor"><path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z"/></svg>`;
+        const sendIcon = `<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="currentColor"><path d="M2.01 21L23 12 2.01 3 2 10l15 2-15 2z"/></svg>`;
 
         const chatbotHTML = `
         <div id="aicp-chat-window">


### PR DESCRIPTION
## Summary
- update the `sendIcon` constant in `chatbot.js` to use a valid SVG `xmlns`

## Testing
- `node - <<'NODE'
const fs = require('fs');
const content = fs.readFileSync('ai-chatbot-pro/assets/js/chatbot.js','utf8');
const match = content.match(/const sendIcon = `([^`]+)`;/);
console.log(match[1]);
NODE`

------
https://chatgpt.com/codex/tasks/task_e_687bd3d943c883308e1c103d78c433f5