### PR TITLE
Lead considered complete with email or phone

### DIFF
--- a/ai-chatbot-pro/assets/js/chatbot.js
+++ b/ai-chatbot-pro/assets/js/chatbot.js
@@ -157,21 +157,24 @@ jQuery(function($) {
     }
 
     function checkLeadCompleteness() {
-        const requiredFields = ['email', 'name', 'phone', 'website'];
-        const missingFields = requiredFields.filter(field => !leadData[field]);
-        
-        if (missingFields.length === 0) {
+        const hasContact = leadData.email || leadData.phone;
+
+        if (hasContact) {
             leadData.isComplete = true;
             isCollectingLeadData = false;
             currentLeadField = null;
-            
+
             // Enviar datos del lead al servidor
             saveLead();
-            
+
             return true;
         }
-        
-        return missingFields;
+
+        const missing = [];
+        if (!leadData.email) missing.push('email');
+        if (!leadData.phone) missing.push('phone');
+
+        return missing;
     }
 
     function askForMissingLeadData(missingFields) {

--- a/ai-chatbot-pro/includes/class-lead-manager.php
+++ b/ai-chatbot-pro/includes/class-lead-manager.php
@@ -97,11 +97,9 @@ class AICP_Lead_Manager {
         // Determinar campos faltantes
         $required_fields = ['name', 'email', 'phone', 'website'];
         $missing_fields = array_diff($required_fields, array_keys($lead_data));
-        
-        // Solo consideramos lead completo si tenemos al menos email o teléfono
-        $is_complete_lead = (isset($lead_data['email']) || isset($lead_data['phone'])) && 
-                           isset($lead_data['name']) && 
-                           isset($lead_data['website']);
+
+        // Un lead se considera completo si tiene email o teléfono
+        $is_complete_lead = isset($lead_data['email']) || isset($lead_data['phone']);
         
         return [
             'has_lead' => $has_contact,


### PR DESCRIPTION
## Summary
- loosen lead completion logic in PHP and JS
- check only for email or phone to mark lead as complete

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_687bd556b0d48330be12e4f86fc96509