### PR TITLE
Fix calendar link in lead follow-up

### DIFF
--- a/ai-chatbot-pro/assets/js/chatbot.js
+++ b/ai-chatbot-pro/assets/js/chatbot.js
@@ -219,8 +219,10 @@ jQuery(function($) {
                     // Si hay URL de calendario, ofrecer cita con enlace real
                     if (params.calendar_url) {
                         setTimeout(() => {
-                            addMessageToChat('bot', 
-                                "¡Perfecto! Aquí tienes la URL del calendario para que puedas reservar una llamada con nuestro equipo en el momento que mejor te convenga: [URL del calendario]"
+                            addMessageToChat(
+                                'bot',
+                                '¡Perfecto! Aquí tienes la URL del calendario para que puedas reservar una llamada con nuestro equipo en el momento que mejor te convenga.',
+                                true
                             );
                         }, 1500);
                     }


### PR DESCRIPTION
## Summary
- ensure calendar follow-up message uses addMessageToChat with the calendar URL link

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_687bd55be6d48330af217b20c54caf20