### PR TITLE
Fix uninstall cleanup

### DIFF
--- a/ai-chatbot-pro/includes/class-installer.php
+++ b/ai-chatbot-pro/includes/class-installer.php
@@ -239,9 +239,11 @@ class AICP_Installer {
     public static function uninstall() {
         global $wpdb;
         
-        // Eliminar tablas
-        $table_name = $wpdb->prefix . 'aicp_chat_logs';
-        $wpdb->query("DROP TABLE IF EXISTS $table_name");
+        // Eliminar tablas personalizadas
+        $logs_table  = $wpdb->prefix . 'aicp_chat_logs';
+        $leads_table = $wpdb->prefix . 'aicp_leads';
+        $wpdb->query("DROP TABLE IF EXISTS $logs_table");
+        $wpdb->query("DROP TABLE IF EXISTS $leads_table");
         
         // Eliminar opciones
         delete_option('aicp_settings');

--- a/ai-chatbot-pro/uninstall.php
+++ b/ai-chatbot-pro/uninstall.php
@@ -5,12 +5,10 @@
  * @package AI_Chatbot_Pro
  */
 
-if (!defined('WP_UNINSTALL_PLUGIN')) exit;
+if (!defined('WP_UNINSTALL_PLUGIN')) {
+    exit;
+}
 
-// Eliminar opciones
-delete_option('aicp_settings');
-delete_option('aicp_db_version');
+require_once __DIR__ . '/includes/class-installer.php';
 
-// Eliminar tabla de logs
-global $wpdb;
-$wpdb->query("DROP TABLE IF EXISTS {$wpdb->prefix}aicp_chat_logs");
+AICP_Installer::uninstall();


### PR DESCRIPTION
## Summary
- use `AICP_Installer::uninstall()` when plugin is removed
- drop leads table during uninstall

## Testing
- `php -l uninstall.php`
- `php -l includes/class-installer.php`
- `find . -name '*.php' -not -path './vendor/*' | xargs -I{} php -l {}`

------
https://chatgpt.com/codex/tasks/task_e_687bd789a2c8833099e37571c78a8489