### PR TITLE
Add save action hook on conversation update

### DIFF
--- a/ai-chatbot-pro/includes/class-ajax-handler.php
+++ b/ai-chatbot-pro/includes/class-ajax-handler.php
@@ -52,9 +52,14 @@ class AICP_Ajax_Handler {
         }
 
      
-      if($log_id > 0) { $wpdb->update($table_name, $data, ['id' => $log_id], $format, ['%d']); }
-
-        else { $wpdb->insert($table_name, $data, $format); $log_id = $wpdb->insert_id; do_action('aicp_conversation_saved', $log_id, $assistant_id, $conversation);
+        if ( $log_id > 0 ) {
+            $wpdb->update( $table_name, $data, [ 'id' => $log_id ], $format, ['%d'] );
+            do_action( 'aicp_conversation_saved', $log_id, $assistant_id, $conversation );
+        } else {
+            $wpdb->insert( $table_name, $data, $format );
+            $log_id = $wpdb->insert_id;
+            do_action( 'aicp_conversation_saved', $log_id, $assistant_id, $conversation );
+        }
 
         return $log_id;
     }


### PR DESCRIPTION
## Summary
- fire `aicp_conversation_saved` when updating a conversation as well as inserting
- ensure `save_conversation()` returns consistently

## Testing
- `php -l ai-chatbot-pro/includes/class-ajax-handler.php`

------
https://chatgpt.com/codex/tasks/task_e_687be9da053883308fc93ebd3218cebf