### PR TITLE
Improve phone detection

### DIFF
--- a/ai-chatbot-pro/assets/js/chatbot.js
+++ b/ai-chatbot-pro/assets/js/chatbot.js
@@ -23,7 +23,7 @@ jQuery(function($) {
     // --- Patrones de detección de leads ---
     const leadPatterns = {
         email: /\b[A-Za-z0-9._%+-]+@[A-Za-z0-9.-]+\.[A-Z|a-z]{2,}\b/g,
-        phone: /(?:\+?34\s?)?(?:6|7|8|9)\d{8}|(?:\+?34\s?)?(?:91|93|94|95|96|97|98)\d{7}/g,
+        phone: /(?:\b(?:\+34|0034|34)?[\s-]?[6789]\d{2}[\s-]?\d{2}[\s-]?\d{2}[\s-]?\d{2}\b|\b\d{3}[\s-]?\d{3}[\s-]?\d{3}\b)/g,
         website: /(?:https?:\/\/)?(?:www\.)?[a-zA-Z0-9-]+\.[a-zA-Z]{2,}(?:\/[^\s]*)?/g
     };
 


### PR DESCRIPTION
## Summary
- allow spaces and dashes in client-side phone regex so numbers like `912 345 678` are detected

## Testing
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687bf45c499483309c3f3e4ae921f370