### PR TITLE
Store detected leads in leads table

### DIFF
--- a/ai-chatbot-pro/includes/class-lead-manager.php
+++ b/ai-chatbot-pro/includes/class-lead-manager.php
@@ -155,7 +155,26 @@ class AICP_Lead_Manager {
                 ['%d', '%s', '%s'],
                 ['%d']
             );
-            
+
+            $leads_table = $wpdb->prefix . 'aicp_leads';
+            $status      = $lead_status;
+
+            $wpdb->insert(
+                $leads_table,
+                [
+                    'log_id'       => $log_id,
+                    'assistant_id' => $assistant_id,
+                    'email'        => $lead_info['data']['email'] ?? '',
+                    'name'         => $lead_info['data']['name'] ?? '',
+                    'phone'        => $lead_info['data']['phone'] ?? '',
+                    'website'      => $lead_info['data']['website'] ?? '',
+                    'lead_data'    => wp_json_encode($lead_info['data'], JSON_UNESCAPED_UNICODE),
+                    'status'       => $status,
+                    'created_at'   => current_time('mysql'),
+                ],
+                ['%d','%d','%s','%s','%s','%s','%s','%s']
+            );
+
             // Hook para integraciones externas
             do_action('aicp_lead_detected', $lead_info['data'], $assistant_id, $log_id, $lead_status);
         }


### PR DESCRIPTION
## Summary
- insert leads into the `aicp_leads` table when a conversation includes contact info
- keep the existing webhook trigger after insertion

## Testing
- `php -l ai-chatbot-pro/includes/class-lead-manager.php`
- `phpunit -c phpunit.xml tests` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fc80ea3c88330851e614032545e1b