### PR TITLE
Remove outdated lead form fields

### DIFF
--- a/ai-chatbot-pro/admin/assistant-meta-boxes.php
+++ b/ai-chatbot-pro/admin/assistant-meta-boxes.php
@@ -109,20 +109,6 @@ function aicp_render_instructions_tab($v) {
         <tr><th><label for="aicp_length_tone"><?php _e('Longitud y Tono', 'ai-chatbot-pro'); ?></label></th><td><textarea name="aicp_settings[length_tone]" id="aicp_length_tone" rows="3" class="large-text"><?php echo esc_textarea($v['length_tone'] ?? 'Intenta ser lo más concisa posible, manteniendo un tono amable y profesional.'); ?></textarea></td></tr>
         <tr><th><label for="aicp_example"><?php _e('Ejemplo de Respuesta', 'ai-chatbot-pro'); ?></label></th><td><textarea name="aicp_settings[example]" id="aicp_example" rows="5" class="large-text"><?php echo esc_textarea($v['example'] ?? 'Si el cliente pregunta por el precio de una web, responde: "El precio de una web puede variar mucho, pero para darte una idea, nuestros proyectos suelen empezar en 1.500€. ¿Te gustaría que te preparásemos un presupuesto detallado sin compromiso?"'); ?></textarea></td></tr>
         <tr><th><label><?php _e('Mensajes Sugeridos', 'ai-chatbot-pro'); ?></label></th><td><input type="text" name="aicp_settings[suggested_messages][]" value="<?php echo esc_attr($v['suggested_messages'][0] ?? ''); ?>" class="large-text" placeholder="<?php _e('Ej: Me interesa el servicio de SEO', 'ai-chatbot-pro'); ?>"><br><input type="text" name="aicp_settings[suggested_messages][]" value="<?php echo esc_attr($v['suggested_messages'][1] ?? ''); ?>" class="large-text" placeholder="<?php _e('Ej: Quiero una web económica', 'ai-chatbot-pro'); ?>"><br><input type="text" name="aicp_settings[suggested_messages][]" value="<?php echo esc_attr($v['suggested_messages'][2] ?? ''); ?>" class="large-text" placeholder="<?php _e('Ej: ¿Podéis llamarme?', 'ai-chatbot-pro'); ?>"><p class="description"><?php _e('Estos mensajes aparecerán como botones clicables para el usuario.', 'ai-chatbot-pro'); ?></p></td></tr>
-        <tr>
-            <th><label for="aicp_calendar_url"><?php _e('URL del Calendario para Reservar Cita', 'ai-chatbot-pro'); ?></label></th>
-            <td>
-                <input type="url" name="aicp_settings[calendar_url]" id="aicp_calendar_url" class="regular-text" value="<?php echo esc_attr($v['calendar_url'] ?? ''); ?>">
-                <p class="description"><?php _e('Si lo rellenas, el bot podrá sugerir este enlace para reservar cita cuando detecte intención de agendar.', 'ai-chatbot-pro'); ?></p>
-            </td>
-        </tr>
-        <tr>
-            <th><label for="aicp_lead_detection"><?php _e('Detección de Leads Mejorada', 'ai-chatbot-pro'); ?></label></th>
-            <td>
-                <label><input type="checkbox" name="aicp_settings[enhanced_lead_detection]" value="1" <?php checked($v['enhanced_lead_detection'] ?? 0, 1); ?>> <?php _e('Activar detección avanzada de leads (nombre, email, teléfono y web)', 'ai-chatbot-pro'); ?></label>
-                <p class="description"><?php _e('El bot pedirá automáticamente estos datos si no los detecta en la conversación.', 'ai-chatbot-pro'); ?></p>
-            </td>
-        </tr>
     </table>
     <?php
 }
@@ -190,29 +176,7 @@ function aicp_render_leads_tab($assistant_id, $v) {
         }
     }
 
-    $hide_icons = $v['hide_lead_icons'] ?? 0;
-    $lead_questions = $v['lead_form_questions'] ?? [];
-    ?>
-    <p>
-        <label>
-            <input type="checkbox" name="aicp_settings[hide_lead_icons]" value="1" <?php checked($hide_icons, 1); ?>>
-            <?php _e('Ocultar iconos de lead en el historial para leads listados aquí', 'ai-chatbot-pro'); ?>
-        </label>
-    </p>
-    <h4><?php _e('Preguntas del Formulario de Leads', 'ai-chatbot-pro'); ?></h4>
-    <div id="aicp-lead-questions">
-        <?php
-        if (!empty($lead_questions) && is_array($lead_questions)) {
-            foreach ($lead_questions as $question) {
-                echo '<div class="aicp-lead-question"><input type="text" name="aicp_settings[lead_form_questions][]" value="' . esc_attr($question) . '" class="regular-text"> <button type="button" class="button aicp-remove-question">&times;</button></div>';
-            }
-        } else {
-            echo '<div class="aicp-lead-question"><input type="text" name="aicp_settings[lead_form_questions][]" value="" class="regular-text"> <button type="button" class="button aicp-remove-question">&times;</button></div>';
-        }
-        ?>
-    </div>
-    <p><button type="button" class="button" id="aicp-add-question"><?php _e('Añadir pregunta', 'ai-chatbot-pro'); ?></button></p>
-    <?php
+
     if (empty($leads)) {
         echo '<p>' . __('Aún no se han detectado leads.', 'ai-chatbot-pro') . '</p>';
         return;
@@ -330,14 +294,6 @@ function aicp_save_meta_box_data($post_id) {
     $current['color_user_text'] = isset($s['color_user_text']) ? sanitize_hex_color($s['color_user_text']) : '#000000';
     
     // Nuevos campos
-    $current['calendar_url'] = isset($s['calendar_url']) ? esc_url_raw($s['calendar_url']) : '';
-    $current['enhanced_lead_detection'] = isset($s['enhanced_lead_detection']) ? 1 : 0;
-    $current['hide_lead_icons'] = isset($s['hide_lead_icons']) ? 1 : 0;
-    if (isset($s['lead_form_questions']) && is_array($s['lead_form_questions'])) {
-        $current['lead_form_questions'] = array_filter(array_map('sanitize_text_field', $s['lead_form_questions']));
-    } else {
-        $current['lead_form_questions'] = [];
-    }
     
     // Los campos PRO se guardan vacíos en la versión gratuita
     $current['training_post_types'] = [];

--- a/ai-chatbot-pro/assets/js/chatbot.js
+++ b/ai-chatbot-pro/assets/js/chatbot.js
@@ -54,8 +54,6 @@ jQuery(function($) {
             <span class="aicp-open-icon"><img src="${params.open_icon}" alt="Abrir chat"></span>
             <span class="aicp-close-icon">${closeIcon}</span>
         </button>
-        <button id="aicp-lead-form-btn" class="aicp-lead-form-btn">Solicitar Información</button>
-        <div id="aicp-lead-form-overlay"><form id="aicp-lead-form"><h3>Solicitud de Información</h3><div class="aicp-lead-fields"></div><p><button type="submit" class="button">Enviar</button> <button type="button" id="aicp-lead-cancel" class="button">Cancelar</button></p></form></div>
         `;
         $('#aicp-chatbot-container').addClass(`position-${params.position}`).html(chatbotHTML);
         renderSuggestedReplies();
@@ -417,60 +415,14 @@ jQuery(function($) {
         });
     }
 
-    function buildLeadFields() {
-        const $fields = $('#aicp-lead-form .aicp-lead-fields');
-        if (!$fields.length) return;
-        $fields.empty();
-        if (Array.isArray(params.lead_questions) && params.lead_questions.length > 0) {
-            params.lead_questions.forEach((q, i) => {
-                const field = `<div class="aicp-lead-field"><label>${q}</label><input type="text" name="lead_${i}" required></div>`;
-                $fields.append(field);
-            });
-        }
-    }
-
-    function showLeadForm() {
-        buildLeadFields();
-        $('#aicp-lead-form-overlay').fadeIn(200);
-    }
-
-    function hideLeadForm() {
-        $('#aicp-lead-form-overlay').fadeOut(200);
-    }
-
-    function submitLeadForm(e) {
-        e.preventDefault();
-        const answers = {};
-        $('#aicp-lead-form').find('input').each(function(idx){
-            const key = params.lead_questions[idx] || `q${idx}`;
-            answers[key] = $(this).val();
-        });
-        $.post(params.ajax_url, {
-            action: 'aicp_submit_lead_form',
-            nonce: params.nonce,
-            assistant_id: params.assistant_id,
-            answers: answers
-        }, function(response){
-            if(response.success){
-                alert('¡Gracias! Hemos recibido tu solicitud.');
-                hideLeadForm();
-            } else {
-                alert('Error al enviar el formulario');
-            }
-        });
-    }
 
     // --- Inicialización ---
     if ($('#aicp-chatbot-container').length > 0) {
         buildChatHTML();
         $(document).on('click', '#aicp-chat-toggle-button', toggleChatWindow);
-        $(document).on('click', '#aicp-lead-form-btn', showLeadForm);
-        $(document).on('click', '#aicp-lead-cancel', hideLeadForm);
-        $(document).on('submit', '#aicp-lead-form', submitLeadForm);
         $(document).on('submit', '#aicp-chat-form', handleFormSubmit);
         $(document).on('click', '.aicp-suggested-reply', handleSuggestedReplyClick);
         $(document).on('click', '.aicp-feedback-btn', handleFeedbackClick);
         $(document).on('click', '.aicp-calendar-link', handleCalendarClick);
-        buildLeadFields();
     }
 });

--- a/ai-chatbot-pro/includes/class-frontend-loader.php
+++ b/ai-chatbot-pro/includes/class-frontend-loader.php
@@ -94,13 +94,8 @@ class AICP_Frontend_Loader {
             $suggested_messages = array_filter(array_map('trim', explode("\n", $s['suggested_messages'])));
         }
 
-        // Obtener URL del calendario si está configurada
-        $calendar_url = !empty($s['calendar_url']) ? esc_url($s['calendar_url']) : '';
-
         // Obtener configuración de detección de leads
-        $enhanced_lead_detection = !empty($s['enhanced_lead_detection']) ? true : false;
         $lead_auto_collect = !empty($s['lead_auto_collect']) ? true : false;
-        $lead_questions = !empty($s['lead_form_questions']) && is_array($s['lead_form_questions']) ? array_values($s['lead_form_questions']) : [];
 
         wp_localize_script('aicp-chatbot-script', 'aicp_chatbot_params', [
             'ajax_url' => admin_url('admin-ajax.php'),
@@ -114,10 +109,7 @@ class AICP_Frontend_Loader {
             'position' => $s['position'] ?? 'br',
             'open_icon' => !empty($s['open_icon_url']) ? esc_url($s['open_icon_url']) : $default_bot_avatar,
             'suggested_messages' => $suggested_messages,
-            'calendar_url' => $calendar_url,
-            'enhanced_lead_detection' => $enhanced_lead_detection,
             'lead_auto_collect' => $lead_auto_collect,
-            'lead_questions' => $lead_questions,
         ]);
     }
 


### PR DESCRIPTION
## Summary
- drop unused lead form modal and handlers from chatbot.js
- remove calendar and lead form options from assistant meta box
- stop passing removed options to the frontend

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687fc8116d888330852303ef4f3dbf33