### PR TITLE
Add customizable lead prompts

### DIFF
--- a/ai-chatbot-pro/admin/assistant-meta-boxes.php
+++ b/ai-chatbot-pro/admin/assistant-meta-boxes.php
@@ -175,6 +175,24 @@ function aicp_render_leads_tab($assistant_id, $v) {
         }
     }
 
+    $auto_collect = !empty($v['lead_auto_collect']);
+    $prompts = $v['lead_prompts'] ?? [];
+
+    echo '<h4>' . __('Ajustes de Captura de Leads', 'ai-chatbot-pro') . '</h4>';
+    echo '<p><label><input type="checkbox" name="aicp_settings[lead_auto_collect]" value="1" ' . checked($auto_collect, true, false) . '> ' . __('Solicitar datos de contacto automáticamente', 'ai-chatbot-pro') . '</label></p>';
+    echo '<table class="form-table"><tbody>';
+    $fields = [
+        'name'    => __('Mensaje para Nombre', 'ai-chatbot-pro'),
+        'email'   => __('Mensaje para Email', 'ai-chatbot-pro'),
+        'phone'   => __('Mensaje para Teléfono', 'ai-chatbot-pro'),
+        'website' => __('Mensaje para Web', 'ai-chatbot-pro')
+    ];
+    foreach ($fields as $key => $label) {
+        $value = esc_attr($prompts[$key] ?? '');
+        echo '<tr><th><label for="aicp_prompt_' . esc_attr($key) . '">' . esc_html($label) . '</label></th><td><input type="text" id="aicp_prompt_' . esc_attr($key) . '" name="aicp_settings[lead_prompts][' . esc_attr($key) . ']" value="' . $value . '" class="regular-text"></td></tr>';
+    }
+    echo '</tbody></table>';
+
 
     if (empty($leads)) {
         echo '<p>' . __('Aún no se han detectado leads.', 'ai-chatbot-pro') . '</p>';
@@ -284,7 +302,15 @@ function aicp_save_meta_box_data($post_id) {
     $current['color_bot_text'] = isset($s['color_bot_text']) ? sanitize_hex_color($s['color_bot_text']) : '#333333';
     $current['color_user_bg'] = isset($s['color_user_bg']) ? sanitize_hex_color($s['color_user_bg']) : '#dcf8c6';
     $current['color_user_text'] = isset($s['color_user_text']) ? sanitize_hex_color($s['color_user_text']) : '#000000';
-    
+
+    // Ajustes de captura de leads
+    $current['lead_auto_collect'] = !empty($s['lead_auto_collect']) ? 1 : 0;
+    if (isset($s['lead_prompts']) && is_array($s['lead_prompts'])) {
+        $current['lead_prompts'] = array_map('sanitize_text_field', $s['lead_prompts']);
+    } else {
+        $current['lead_prompts'] = [];
+    }
+
     // Nuevos campos
     
     // Los campos PRO se guardan vacíos en la versión gratuita

--- a/ai-chatbot-pro/assets/js/chatbot.js
+++ b/ai-chatbot-pro/assets/js/chatbot.js
@@ -179,20 +179,16 @@ jQuery(function($) {
     }
 
     function askForMissingLeadData(missingFields) {
-        if (missingFields.length === 0) return;
-        
+        if (!params.lead_auto_collect || missingFields.length === 0) return;
+
         isCollectingLeadData = true;
         currentLeadField = missingFields[0];
-        
-        const fieldMessages = {
-            name: "Para poder ayudarte mejor, ¿podrías decirme tu nombre?",
-            email: "¿Podrías proporcionarme tu email para enviarte más información?",
-            phone: "¿Cuál es tu número de teléfono para contactarte?",
-            website: "¿Tienes algún sitio web que te gustaría que revisemos?"
-        };
-        
-        const message = fieldMessages[currentLeadField] || "¿Podrías proporcionar más información?";
-        
+
+        const messages = params.lead_prompt_messages || {};
+        const message = messages[currentLeadField];
+
+        if (!message) return;
+
         setTimeout(() => {
             addMessageToChat('bot', message);
         }, 1000);

--- a/ai-chatbot-pro/includes/class-frontend-loader.php
+++ b/ai-chatbot-pro/includes/class-frontend-loader.php
@@ -95,7 +95,8 @@ class AICP_Frontend_Loader {
         }
 
         // Obtener configuración de detección de leads
-        $lead_auto_collect = !empty($s['lead_auto_collect']) ? true : false;
+        $lead_auto_collect  = !empty($s['lead_auto_collect']) ? true : false;
+        $lead_prompt_messages = $s['lead_prompts'] ?? [];
 
         wp_localize_script('aicp-chatbot-script', 'aicp_chatbot_params', [
             'ajax_url' => admin_url('admin-ajax.php'),
@@ -109,7 +110,8 @@ class AICP_Frontend_Loader {
             'position' => $s['position'] ?? 'br',
             'open_icon' => !empty($s['open_icon_url']) ? esc_url($s['open_icon_url']) : $default_bot_avatar,
             'suggested_messages' => $suggested_messages,
-            'lead_auto_collect' => $lead_auto_collect,
+            'lead_auto_collect'  => $lead_auto_collect,
+            'lead_prompt_messages' => $lead_prompt_messages,
         ]);
     }
 


### PR DESCRIPTION
## Summary
- make lead prompts configurable per assistant and rely on JS for customized text
- load lead prompt settings in the frontend
- allow disabling automatic lead prompts

## Testing
- `php -l ai-chatbot-pro/admin/assistant-meta-boxes.php`
- `php -l ai-chatbot-pro/includes/class-frontend-loader.php`
- `php -l ai-chatbot-pro/includes/class-lead-manager.php`
- `node -e "require('fs').readFileSync('ai-chatbot-pro/assets/js/chatbot.js','utf8');"`
- `vendor/bin/phpunit` *(fails: composer install blocked)*

------
https://chatgpt.com/codex/tasks/task_e_687fce0ed3a08330a6031ab19d680be9