### PR TITLE
Add partial lead hook

### DIFF
--- a/ai-chatbot-pro/README.txt
+++ b/ai-chatbot-pro/README.txt
@@ -27,6 +27,21 @@ AI Chatbot Pro te permite crear asistentes de chat personalizables usando la API
 = ¿Necesito una clave de API de OpenAI? =
 Sí, debes introducir tu clave de API de OpenAI para que el chatbot pueda comunicarse con la plataforma.
 
+== JavaScript hooks ==
+Se expone la función global `aicpLeadMissing` para que los temas o plugins puedan reaccionar cuando el bot detecta un lead incompleto.
+
+Ejemplo básico:
+
+```
+<script>
+window.aicpLeadMissing = function(info) {
+    // info.missingFields contiene los campos faltantes
+    // Aquí podrías mostrar tu propio formulario
+    console.log('Faltan datos:', info.missingFields);
+};
+</script>
+```
+
 == Changelog ==
 = 5.1.0 =
 * Versión inicial del plugin.

--- a/ai-chatbot-pro/assets/js/chatbot.js
+++ b/ai-chatbot-pro/assets/js/chatbot.js
@@ -322,24 +322,25 @@ jQuery(function($) {
                     const botReply = response.data.reply;
                     logId = response.data.log_id;
                     conversationHistory.push({ role: 'assistant', content: botReply });
-                    
-                    // Verificar si la respuesta del bot sugiere contacto y no tenemos lead completo
-                    const contactKeywords = ['contacto', 'email', 'teléfono', 'llamar', 'escribir', 'información'];
-                    const suggestsContact = contactKeywords.some(keyword => 
-                        botReply.toLowerCase().includes(keyword)
-                    );
-                    
+
                     addMessageToChat('bot', botReply);
-                    
-                    // Si sugiere contacto y no tenemos lead completo, empezar recolección
-                    if (suggestsContact && !leadData.isComplete) {
-                        const missingFields = checkLeadCompleteness();
-                        if (missingFields !== true && missingFields.length > 0) {
-                            askForMissingLeadData(missingFields);
+
+                    const leadStatus = response.data.lead_status;
+                    const missing = response.data.missing_fields || [];
+
+                    if (leadStatus === 'partial') {
+                        if (typeof window.aicpLeadMissing === 'function') {
+                            window.aicpLeadMissing({
+                                logId: logId,
+                                assistantId: params.assistant_id,
+                                missingFields: missing
+                            });
+                        } else if (!leadData.isComplete && missing.length > 0) {
+                            askForMissingLeadData(missing);
                         }
                     }
-                } else { 
-                    addMessageToChat('bot', `Error: ${response.data.message}`); 
+                } else {
+                    addMessageToChat('bot', `Error: ${response.data.message}`);
                 }
             },
             error: () => addMessageToChat('bot', 'Lo siento, ha ocurrido un error de conexión.'),


### PR DESCRIPTION
## Summary
- run `AICP_Lead_Manager::detect_contact_data` when replying to chat
- pass `lead_status` and missing fields back to JS
- expose a JavaScript hook `aicpLeadMissing` for partial leads
- document hook usage in README

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*

------
https://chatgpt.com/codex/tasks/task_e_687fce1bee1c8330902f42e7634b203a