### PR TITLE
Add lead capture buttons

### DIFF
--- a/ai-chatbot-pro/admin/assistant-meta-boxes.php
+++ b/ai-chatbot-pro/admin/assistant-meta-boxes.php
@@ -190,6 +190,16 @@ function aicp_render_leads_tab($assistant_id, $v) {
     }
     echo '</tbody></table>';
 
+    $closing = $v['lead_closing_messages'] ?? [];
+    echo '<h4>' . __('Mensajes de Cierre', 'ai-chatbot-pro') . '</h4>';
+    echo '<table class="form-table"><tbody>';
+    for ($i = 0; $i < 3; $i++) {
+        $val = esc_attr($closing[$i] ?? '');
+        $label = sprintf(__('Mensaje %d', 'ai-chatbot-pro'), $i + 1);
+        echo '<tr><th><label>' . esc_html($label) . '</label></th><td><input type="text" name="aicp_settings[lead_closing_messages][]" value="' . $val . '" class="regular-text"></td></tr>';
+    }
+    echo '</tbody></table>';
+
 
 
     if (empty($leads)) {
@@ -307,6 +317,12 @@ function aicp_save_meta_box_data($post_id) {
         $current['lead_prompts'] = array_map('sanitize_text_field', $s['lead_prompts']);
     } else {
         $current['lead_prompts'] = [];
+    }
+
+    if (isset($s['lead_closing_messages']) && is_array($s['lead_closing_messages'])) {
+        $current['lead_closing_messages'] = array_map('sanitize_text_field', $s['lead_closing_messages']);
+    } else {
+        $current['lead_closing_messages'] = [];
     }
 
     // Nuevos campos

--- a/ai-chatbot-pro/assets/css/chatbot.css
+++ b/ai-chatbot-pro/assets/css/chatbot.css
@@ -85,6 +85,11 @@
 .aicp-suggested-reply { background-color: #fff; border: 1px solid #ccc; border-radius: 20px; padding: 6px 12px; font-size: 0.85em; cursor: pointer; transition: background-color 0.2s; }
 .aicp-suggested-reply:hover { background-color: #e9e9e9; }
 
+/* Botones de cierre de lead */
+.aicp-lead-buttons { padding: 0 15px 10px; display: none; flex-wrap: wrap; gap: 8px; }
+.aicp-lead-button { background-color: #fff; border: 1px solid #ccc; border-radius: 20px; padding: 6px 12px; font-size: 0.85em; cursor: pointer; transition: background-color 0.2s; }
+.aicp-lead-button:hover { background-color: #e9e9e9; }
+
 /* Pie de página */
 .aicp-chat-footer { padding: 10px 15px; background: #fff; border-top: 1px solid #e0e0e0; flex-shrink: 0; }
 .aicp-chat-footer form { display: flex; align-items: center; gap: 10px; }

--- a/ai-chatbot-pro/assets/js/chatbot.js
+++ b/ai-chatbot-pro/assets/js/chatbot.js
@@ -20,6 +20,8 @@ jQuery(function($) {
     };
     let isCollectingLeadData = false;
     let currentLeadField = null;
+    let userMessageCount = 0;
+    let leadButtonsShown = false;
 
     // --- Patrones de detección de leads ---
     const leadPatterns = {
@@ -27,6 +29,7 @@ jQuery(function($) {
         phone: /(?:\+?34[\s-]?)(?:6|7|8|9)[\s-]?\d{2}[\s-]?\d{2}[\s-]?\d{2}[\s-]?\d{2}|(?:\+?34[\s-]?)(?:91|93|94|95|96|97|98)[\s-]?\d{3}[\s-]?\d{3}/g,
         website: /(?:https?:\/\/)?(?:www\.)?[a-zA-Z0-9-]+\.[a-zA-Z]{2,}(?:\/[^\s]*)?/g
     };
+    const leadButtonThreshold = 3;
 
     // --- HTML y UI ---
     function buildChatHTML() {
@@ -43,6 +46,7 @@ jQuery(function($) {
             </div>
             <div class="aicp-chat-body"></div>
             <div class="aicp-suggested-replies"></div>
+            <div class="aicp-lead-buttons"></div>
             <div class="aicp-chat-footer">
                 <form id="aicp-chat-form">
                     <input type="text" id="aicp-chat-input" placeholder="Escribe un mensaje..." autocomplete="off">
@@ -57,9 +61,10 @@ jQuery(function($) {
         `;
         $('#aicp-chatbot-container').addClass(`position-${params.position}`).html(chatbotHTML);
         renderSuggestedReplies();
+        renderLeadButtons();
     }
 
-    function renderSuggestedReplies() {
+function renderSuggestedReplies() {
         const $container = $('.aicp-suggested-replies');
         if (!params.suggested_messages || params.suggested_messages.length === 0) {
             $container.hide();
@@ -72,6 +77,22 @@ jQuery(function($) {
                 $container.append($button);
             }
         });
+    }
+
+    function renderLeadButtons() {
+        const $container = $('.aicp-lead-buttons');
+        if (!params.lead_capture_buttons || params.lead_capture_buttons.length === 0) {
+            $container.hide();
+            return;
+        }
+        $container.empty();
+        params.lead_capture_buttons.forEach(msg => {
+            if (msg) {
+                const $btn = $('<button class="aicp-lead-button"></button>').text(msg);
+                $container.append($btn);
+            }
+        });
+        $container.hide();
     }
 
     function toggleChatWindow() {
@@ -267,13 +288,27 @@ jQuery(function($) {
         $('#aicp-send-button').prop('disabled', true);
     }
     
-    function scrollToBottom() { 
-        const $chatBody = $('.aicp-chat-body'); 
-        $chatBody.scrollTop($chatBody[0].scrollHeight); 
+    function scrollToBottom() {
+        const $chatBody = $('.aicp-chat-body');
+        $chatBody.scrollTop($chatBody[0].scrollHeight);
+    }
+
+    function maybeShowLeadButtons() {
+        if (leadButtonsShown) return;
+        if (userMessageCount >= leadButtonThreshold) {
+            const $container = $('.aicp-lead-buttons');
+            if ($container.children().length > 0) {
+                $container.slideDown();
+                leadButtonsShown = true;
+            }
+        }
     }
 
     function sendMessage(message) {
         if (!message || isThinking || isChatEnded) return;
+
+        userMessageCount++;
+        $('.aicp-lead-buttons').slideUp();
         
         // Detectar datos de lead en el mensaje del usuario
         const leadDetected = detectLeadData(message);
@@ -320,6 +355,7 @@ jQuery(function($) {
                     conversationHistory.push({ role: 'assistant', content: botReply });
 
                     addMessageToChat('bot', botReply);
+                    maybeShowLeadButtons();
 
                     const leadStatus = response.data.lead_status;
                     const missing = response.data.missing_fields || [];
@@ -358,6 +394,15 @@ jQuery(function($) {
     function handleSuggestedReplyClick() {
         const message = $(this).text();
         sendMessage(message);
+    }
+
+    function handleLeadButtonClick() {
+        const message = $(this).text();
+        addMessageToChat('user', message);
+        conversationHistory.push({ role: 'user', content: message });
+        $('.aicp-lead-buttons').slideUp();
+        checkLeadCompleteness();
+        saveLead();
     }
 
     function handleFeedbackClick() {
@@ -421,5 +466,6 @@ jQuery(function($) {
         $(document).on('click', '.aicp-suggested-reply', handleSuggestedReplyClick);
         $(document).on('click', '.aicp-feedback-btn', handleFeedbackClick);
         $(document).on('click', '.aicp-calendar-link', handleCalendarClick);
+        $(document).on('click', '.aicp-lead-button', handleLeadButtonClick);
     }
 });

--- a/ai-chatbot-pro/includes/class-frontend-loader.php
+++ b/ai-chatbot-pro/includes/class-frontend-loader.php
@@ -97,6 +97,7 @@ class AICP_Frontend_Loader {
         // Obtener configuración de detección de leads
         $lead_auto_collect  = !empty($s['lead_auto_collect']) ? true : false;
         $lead_prompt_messages = $s['lead_prompts'] ?? [];
+        $lead_closing_messages = $s['lead_closing_messages'] ?? [];
 
         wp_localize_script('aicp-chatbot-script', 'aicp_chatbot_params', [
             'ajax_url' => admin_url('admin-ajax.php'),
@@ -112,6 +113,7 @@ class AICP_Frontend_Loader {
             'suggested_messages' => $suggested_messages,
             'lead_auto_collect'  => $lead_auto_collect,
             'lead_prompt_messages' => $lead_prompt_messages,
+            'lead_capture_buttons' => $lead_closing_messages,
         ]);
     }
 


### PR DESCRIPTION
## Summary
- add custom "mensajes de cierre" fields in assistant lead settings
- localize closing messages to the frontend
- style closing buttons and render them in the chat UI
- show lead buttons after a few user messages and handle their click

## Testing
- `php -l ai-chatbot-pro/admin/assistant-meta-boxes.php`
- `php -l ai-chatbot-pro/includes/class-frontend-loader.php`
- `phpunit -c phpunit.xml` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fd73c5a348330bfb798dd489ab183