### PR TITLE
Add lead capture button for chatbot

### DIFF
--- a/ai-chatbot-pro/assets/css/chatbot.css
+++ b/ai-chatbot-pro/assets/css/chatbot.css
@@ -93,6 +93,17 @@
 .aicp-chat-footer button:disabled { background-color: #ccc; cursor: not-allowed; }
 .aicp-chat-footer button svg { width: 20px; height: 20px; }
 
+#aicp-capture-lead-btn {
+    margin-left: 8px;
+    padding: 6px 12px;
+    background: var(--aicp-color-primary);
+    color: #fff;
+    border: none;
+    border-radius: 20px;
+    cursor: pointer;
+    font-size: 0.85em;
+}
+
 /* Formulario de leads */
 #aicp-lead-form-overlay { position: fixed; top:0; left:0; right:0; bottom:0; background: rgba(0,0,0,0.6); display:none; align-items:center; justify-content:center; z-index:10001; }
 #aicp-lead-form { background:#fff; padding:20px; border-radius:8px; max-width:400px; width:90%; }

--- a/ai-chatbot-pro/assets/js/chatbot.js
+++ b/ai-chatbot-pro/assets/js/chatbot.js
@@ -48,6 +48,7 @@ jQuery(function($) {
                     <input type="text" id="aicp-chat-input" placeholder="Escribe un mensaje..." autocomplete="off">
                     <button type="submit" id="aicp-send-button" aria-label="Enviar mensaje">${sendIcon}</button>
                 </form>
+                <button type="button" id="aicp-capture-lead-btn">Enviar contacto</button>
             </div>
         </div>
         <button id="aicp-chat-toggle-button" aria-label="Abrir chat">
@@ -412,6 +413,28 @@ jQuery(function($) {
         });
     }
 
+    function handleCaptureLeadClick() {
+        $.ajax({
+            url: params.ajax_url,
+            type: 'POST',
+            data: {
+                action: 'aicp_capture_lead',
+                nonce: params.nonce,
+                assistant_id: params.assistant_id,
+                log_id: logId,
+                conversation: conversationHistory
+            },
+            success: (res) => {
+                if (res.success) {
+                    addMessageToChat('bot', '¡Gracias! Hemos registrado tu interés. ✅');
+                } else {
+                    const msg = res.data && res.data.message ? res.data.message : 'Error al capturar el lead';
+                    addMessageToChat('bot', msg);
+                }
+            }
+        });
+    }
+
 
     // --- Inicialización ---
     if ($('#aicp-chatbot-container').length > 0) {
@@ -421,5 +444,6 @@ jQuery(function($) {
         $(document).on('click', '.aicp-suggested-reply', handleSuggestedReplyClick);
         $(document).on('click', '.aicp-feedback-btn', handleFeedbackClick);
         $(document).on('click', '.aicp-calendar-link', handleCalendarClick);
+        $(document).on('click', '#aicp-capture-lead-btn', handleCaptureLeadClick);
     }
 });


### PR DESCRIPTION
## Summary
- capture leads from the chat manually
- send conversation history to server via new AJAX endpoint
- parse contact data on server and store the lead
- tweak chatbot UI and styles

## Testing
- `composer install` *(fails: CONNECT tunnel failed)*
- `./vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_687fd74179408330aa8db254d560b04b