### PR TITLE
Remove unused lead prompt settings

### DIFF
--- a/ai-chatbot-pro/admin/assistant-meta-boxes.php
+++ b/ai-chatbot-pro/admin/assistant-meta-boxes.php
@@ -173,21 +173,10 @@ function aicp_render_leads_tab($assistant_id, $v) {
 
 
     $auto_collect = !empty($v['lead_auto_collect']);
-    $prompts = $v['lead_prompts'] ?? [];
 
     echo '<h4>' . __('Ajustes de Captura de Leads', 'ai-chatbot-pro') . '</h4>';
     echo '<p><label><input type="checkbox" name="aicp_settings[lead_auto_collect]" value="1" ' . checked($auto_collect, true, false) . '> ' . __('Solicitar datos de contacto automáticamente', 'ai-chatbot-pro') . '</label></p>';
     echo '<table class="form-table"><tbody>';
-    $fields = [
-        'name'    => __('Mensaje para Nombre', 'ai-chatbot-pro'),
-        'email'   => __('Mensaje para Email', 'ai-chatbot-pro'),
-        'phone'   => __('Mensaje para Teléfono', 'ai-chatbot-pro'),
-        'website' => __('Mensaje para Web', 'ai-chatbot-pro')
-    ];
-    foreach ($fields as $key => $label) {
-        $value = esc_attr($prompts[$key] ?? '');
-        echo '<tr><th><label for="aicp_prompt_' . esc_attr($key) . '">' . esc_html($label) . '</label></th><td><input type="text" id="aicp_prompt_' . esc_attr($key) . '" name="aicp_settings[lead_prompts][' . esc_attr($key) . ']" value="' . $value . '" class="regular-text"></td></tr>';
-    }
     echo '</tbody></table>';
 
 
@@ -315,11 +304,8 @@ function aicp_save_meta_box_data($post_id) {
 
     // Ajustes de captura de leads
     $current['lead_auto_collect'] = !empty($s['lead_auto_collect']) ? 1 : 0;
-    if (isset($s['lead_prompts']) && is_array($s['lead_prompts'])) {
-        $current['lead_prompts'] = array_map('sanitize_text_field', $s['lead_prompts']);
-    } else {
-        $current['lead_prompts'] = [];
-    }
+    // Elimina cualquier mensaje de captura previo
+    unset($current['lead_prompts']);
 
     if (isset($s['lead_closing_messages']) && is_array($s['lead_closing_messages'])) {
         $current['lead_closing_messages'] = array_map('sanitize_text_field', $s['lead_closing_messages']);

--- a/ai-chatbot-pro/includes/class-frontend-loader.php
+++ b/ai-chatbot-pro/includes/class-frontend-loader.php
@@ -98,7 +98,6 @@ class AICP_Frontend_Loader {
 
         // Obtener configuración de detección de leads
         $lead_auto_collect  = !empty($s['lead_auto_collect']) ? true : false;
-        $lead_prompt_messages = $s['lead_prompts'] ?? [];
         $lead_closing_messages = $s['lead_closing_messages'] ?? [];
 
         wp_localize_script('aicp-chatbot-script', 'aicp_chatbot_params', [
@@ -114,7 +113,6 @@ class AICP_Frontend_Loader {
             'open_icon' => !empty($s['open_icon_url']) ? esc_url($s['open_icon_url']) : $default_bot_avatar,
             'suggested_messages' => $suggested_messages,
             'lead_auto_collect'  => $lead_auto_collect,
-            'lead_prompt_messages' => $lead_prompt_messages,
             'lead_capture_buttons' => $lead_closing_messages,
         ]);
     }


### PR DESCRIPTION
## Summary
- trim lead prompt fields from admin UI
- stop saving lead prompt messages
- stop localizing lead prompt messages in the frontend

## Testing
- `php -l ai-chatbot-pro/admin/assistant-meta-boxes.php`
- `php -l ai-chatbot-pro/includes/class-frontend-loader.php`
- `composer install` *(fails: CONNECT tunnel failed)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_687fe16008148330a1b47dc574ce7a37