### PR TITLE
Remove lead closing messages and buttons

### DIFF
--- a/ai-chatbot-pro/admin/assistant-meta-boxes.php
+++ b/ai-chatbot-pro/admin/assistant-meta-boxes.php
@@ -177,32 +177,6 @@ function aicp_render_leads_tab($assistant_id, $v) {
     echo '<h4>' . __('Ajustes de Captura de Leads', 'ai-chatbot-pro') . '</h4>';
     echo '<p><label><input type="checkbox" name="aicp_settings[lead_auto_collect]" value="1" ' . checked($auto_collect, true, false) . '> ' . __('Solicitar datos de contacto automáticamente', 'ai-chatbot-pro') . '</label></p>';
     echo '<table class="form-table"><tbody>';
-    echo '</tbody></table>';
-
-
-    $action_msgs = $v['lead_action_messages'] ?? [];
-    if (empty($action_msgs) && !empty($v['lead_closing_messages'])) {
-        $old = (array) $v['lead_closing_messages'];
-        foreach ($old as $msg) {
-            $action_msgs[] = ['text' => $msg, 'url' => ''];
-        }
-    }
-
-    echo '<h4>' . __('Mensajes de Cierre', 'ai-chatbot-pro') . '</h4>';
-    echo '<table class="form-table"><tbody>';
-    for ($i = 0; $i < 3; $i++) {
-        $text = esc_attr($action_msgs[$i]['text'] ?? '');
-        $url  = esc_url($action_msgs[$i]['url'] ?? '');
-        $label = sprintf(__('Mensaje %d', 'ai-chatbot-pro'), $i + 1);
-        echo '<tr><th><label>' . esc_html($label) . '</label></th><td>';
-        echo '<input type="text" name="aicp_settings[lead_action_messages][' . $i . '][text]" value="' . $text . '" class="regular-text" style="margin-right:10px;" />';
-        echo '<input type="url" name="aicp_settings[lead_action_messages][' . $i . '][url]" value="' . $url . '" class="regular-text" placeholder="URL" />';
-        echo '</td></tr>';
-    }
-    echo '</tbody></table>';
-
-
-
 
     if (empty($leads)) {
         echo '<p>' . __('Aún no se han detectado leads.', 'ai-chatbot-pro') . '</p>';
@@ -317,28 +291,6 @@ function aicp_save_meta_box_data($post_id) {
     $current['lead_auto_collect'] = !empty($s['lead_auto_collect']) ? 1 : 0;
     // Elimina cualquier mensaje de captura previo
     unset($current['lead_prompts']);
-
-    $current['lead_action_messages'] = [];
-    if (isset($s['lead_action_messages']) && is_array($s['lead_action_messages'])) {
-        foreach ($s['lead_action_messages'] as $msg) {
-            $text = isset($msg['text']) ? sanitize_text_field($msg['text']) : '';
-            $url  = isset($msg['url']) ? esc_url_raw($msg['url']) : '';
-            if ($text !== '' || $url !== '') {
-                $current['lead_action_messages'][] = [ 'text' => $text, 'url' => $url ];
-            }
-        }
-    } elseif (isset($s['lead_closing_messages']) && is_array($s['lead_closing_messages'])) {
-        foreach ($s['lead_closing_messages'] as $msg) {
-            $current['lead_action_messages'][] = [ 'text' => sanitize_text_field($msg), 'url' => '' ];
-        }
-    }
-    unset($current['lead_closing_messages']);
-
-    if (isset($s['lead_action_messages']) && is_array($s['lead_action_messages'])) {
-        $current['lead_action_messages'] = array_map('sanitize_text_field', $s['lead_action_messages']);
-    } else {
-        $current['lead_action_messages'] = [];
-    }
 
     // Nuevos campos
     

--- a/ai-chatbot-pro/assets/css/chatbot.css
+++ b/ai-chatbot-pro/assets/css/chatbot.css
@@ -85,11 +85,6 @@
 .aicp-suggested-reply { background-color: #fff; border: 1px solid #ccc; border-radius: 20px; padding: 6px 12px; font-size: 0.85em; cursor: pointer; transition: background-color 0.2s; }
 .aicp-suggested-reply:hover { background-color: #e9e9e9; }
 
-/* Botones de cierre de lead */
-.aicp-lead-buttons { padding: 0 15px 10px; display: none; flex-wrap: wrap; gap: 8px; }
-.aicp-lead-button { background-color: #fff; border: 1px solid #ccc; border-radius: 20px; padding: 6px 12px; font-size: 0.85em; cursor: pointer; transition: background-color 0.2s; }
-.aicp-lead-button:hover { background-color: #e9e9e9; }
-
 /* Pie de página */
 .aicp-chat-footer { padding: 10px 15px; background: #fff; border-top: 1px solid #e0e0e0; flex-shrink: 0; }
 .aicp-chat-footer form { display: flex; align-items: center; gap: 10px; }

--- a/ai-chatbot-pro/includes/class-frontend-loader.php
+++ b/ai-chatbot-pro/includes/class-frontend-loader.php
@@ -99,15 +99,6 @@ class AICP_Frontend_Loader {
         // Obtener configuración de detección de leads
         $lead_auto_collect  = !empty($s['lead_auto_collect']) ? true : false;
 
-        $lead_prompt_messages = $s['lead_prompts'] ?? [];
-        $lead_action_messages = $s['lead_action_messages'] ?? [];
-        if (empty($lead_action_messages) && !empty($s['lead_closing_messages'])) {
-            foreach ((array) $s['lead_closing_messages'] as $msg) {
-                $lead_action_messages[] = ['text' => $msg, 'url' => ''];
-            }
-        }
-
-
         wp_localize_script('aicp-chatbot-script', 'aicp_chatbot_params', [
             'ajax_url' => admin_url('admin-ajax.php'),
             'nonce' => wp_create_nonce('aicp_chat_nonce'),
@@ -121,9 +112,6 @@ class AICP_Frontend_Loader {
             'open_icon' => !empty($s['open_icon_url']) ? esc_url($s['open_icon_url']) : $default_bot_avatar,
             'suggested_messages' => $suggested_messages,
             'lead_auto_collect'  => $lead_auto_collect,
-
-            'lead_prompt_messages' => $lead_prompt_messages,
-            'lead_capture_buttons' => $lead_action_messages,
 
         ]);
     }

--- a/tests/test-lead-manager.php
+++ b/tests/test-lead-manager.php
@@ -96,26 +96,4 @@ class Lead_Manager_Test extends WP_UnitTestCase {
         $this->assertSame( $status, $payload['lead_status'] );
     }
 
-    public function test_save_meta_box_sanitizes_lead_action_messages() {
-        $user_id = $this->factory->user->create( [ 'role' => 'administrator' ] );
-        wp_set_current_user( $user_id );
-
-        $assistant_id = $this->factory->post->create( [ 'post_type' => 'aicp_assistant' ] );
-
-        $_POST['aicp_meta_box_nonce'] = wp_create_nonce( 'aicp_save_meta_box_data' );
-        $_POST['aicp_settings'] = [
-            'lead_action_messages' => [
-                ' <b>Hello</b> ',
-                'Good <script>alert("x")</script> '
-            ],
-        ];
-
-        aicp_save_meta_box_data( $assistant_id );
-
-        $settings = get_post_meta( $assistant_id, '_aicp_assistant_settings', true );
-        $expected = array_map( 'sanitize_text_field', [ ' <b>Hello</b> ', 'Good <script>alert("x")</script> ' ] );
-        $this->assertSame( $expected, $settings['lead_action_messages'] );
-
-        $_POST = [];
-    }
 }


### PR DESCRIPTION
## Summary
- remove obsolete lead closing messages section and persistence logic
- strip frontend loader of lead capture button data
- delete lead button UI, logic, and styles; adjust tests

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*
- `phpunit` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6893a6b4c908833085b8f23f64f222b5