### PR TITLE
Include admin script dependency for advanced training addon

### DIFF
--- a/aicp-advanced-training/aicp-advanced-training.php
+++ b/aicp-advanced-training/aicp-advanced-training.php
@@ -41,7 +41,7 @@ function aicp_pro_enqueue_admin_scripts($hook) {
             wp_enqueue_script(
                 'aicp-admin-pro-js',
                 $plugin_url . 'assets/js/admin-pro.js',
-                ['jquery'],
+                ['jquery', 'aicp-admin-script'],
                 '1.0',
                 true
             );


### PR DESCRIPTION
## Summary
- Ensure the advanced training admin script depends on the core admin script.

## Testing
- `composer install` *(fails: curl error 56 while downloading https://repo.packagist.org/packages.json: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c03ad0908330a51a22a75bd6b9d7