### PR TITLE
Include training post type posts in Pinecone sync

### DIFF
--- a/aicp-advanced-training/includes/class-pinecone-manager.php
+++ b/aicp-advanced-training/includes/class-pinecone-manager.php
@@ -17,17 +17,28 @@ class AICP_Pinecone_Manager {
         // Obtenemos los ajustes de ESE asistente para saber qué posts tiene seleccionados.
         $settings = get_post_meta($assistant_id, '_aicp_assistant_settings', true);
         $post_ids_to_index = $settings['training_post_ids'] ?? [];
+
+        $training_post_types = $settings['training_post_types'] ?? [];
+        if (!empty($training_post_types)) {
+            $posts_in_types = get_posts([
+                'post_type'      => $training_post_types,
+                'post_status'    => 'publish',
+                'posts_per_page' => -1,
+                'fields'         => 'ids',
+            ]);
+            $post_ids_to_index = array_unique(array_merge($post_ids_to_index, $posts_in_types));
+        }
         // --- FIN DE LA CORRECCIÓN ---
 
         if (empty($post_ids_to_index)) {
             wp_send_json_error(['message' => 'No has seleccionado ningún contenido para sincronizar en la pestaña de Funciones PRO.']);
         }
-        
+
         $posts_to_index = get_posts([
-            'post__in' => $post_ids_to_index,
-            'post_type' => 'any', // Buscamos en cualquier tipo de post para asegurar que encontramos los IDs
-            'posts_per_page' => -1,
-            'post_status' => 'publish',
+            'post__in'        => $post_ids_to_index,
+            'post_type'       => 'any', // Buscamos en cualquier tipo de post para asegurar que encontramos los IDs
+            'posts_per_page'  => -1,
+            'post_status'     => 'publish',
         ]);
         
         // Si por alguna razón los posts seleccionados ya no existen, devolvemos 0.


### PR DESCRIPTION
## Summary
- load training post type settings and fetch all published posts for those types
- merge fetched post IDs with explicitly selected IDs before indexing

## Testing
- `composer install` *(fails: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(fails: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a4c03eb1508330895b3c0ec6f4150c