### PR TITLE
Añade clase has-image en previsualización

### DIFF
--- a/ai-chatbot-pro/assets/css/admin.css
+++ b/ai-chatbot-pro/assets/css/admin.css
@@ -18,13 +18,17 @@
 
 /* Uploader de imágenes */
 .aicp-uploader-wrapper { display: flex; align-items: center; gap: 10px; }
-.aicp-preview-image { 
-    width: 40px; 
-    height: 40px; 
-    border-radius: 50%; 
-    object-fit: cover; 
-    border: 1px solid #ddd; 
-    background-color: white; 
+.aicp-preview-image {
+    width: 40px;
+    height: 40px;
+    border-radius: 50%;
+    object-fit: cover;
+    border: 1px solid #ddd;
+    background-color: white;
+}
+.aicp-preview-image.has-image {
+    border-color: #46b450;
+    box-shadow: 0 0 0 1px #46b450;
 }
 .aicp-uploader-wrapper img[id="open_icon_preview"] {
     border-radius: 0;

--- a/ai-chatbot-pro/assets/js/admin-scripts.js
+++ b/ai-chatbot-pro/assets/js/admin-scripts.js
@@ -37,6 +37,7 @@ jQuery(function($) {
                 const attachment = mediaUploader.state().get('selection').first().toJSON();
                 const url = attachment.url;
                 $('#' + targetId + '_url').val(url).trigger('change');
+                $('#' + targetId + '_preview').attr('src', url).addClass('has-image');
             });
             mediaUploader.open();
         });
@@ -47,8 +48,9 @@ jQuery(function($) {
             if (targetId === 'bot_avatar') defaultImage = aicp_admin_params.default_bot_avatar;
             else if (targetId === 'user_avatar') defaultImage = aicp_admin_params.default_user_avatar;
             else if (targetId === 'open_icon') defaultImage = aicp_admin_params.default_open_icon;
-            
+
             $('#' + targetId + '_url').val(defaultImage).trigger('change');
+            $('#' + targetId + '_preview').attr('src', defaultImage).removeClass('has-image');
         });
     }
     


### PR DESCRIPTION
## Summary
- Marca las imágenes seleccionadas con la clase `has-image` y actualiza el `src` del preview
- Restaura la previsualización al quitar la imagen
- Añade estilos básicos para `.has-image`

## Testing
- `composer install` (falló: CONNECT tunnel failed 403)
- `vendor/bin/phpunit` (falló: No such file or directory)


------
https://chatgpt.com/codex/tasks/task_e_68a4cae810808330a84feda145df975e