### PR TITLE
Add manual lead capture buttons and hooks

### DIFF
--- a/ai-chatbot-pro/includes/class-frontend-loader.php
+++ b/ai-chatbot-pro/includes/class-frontend-loader.php
@@ -19,6 +19,8 @@ class AICP_Frontend_Loader {
         // AJAX handlers para funcionalidades de lead
         add_action('wp_ajax_aicp_save_lead', [__CLASS__, 'handle_save_lead']);
         add_action('wp_ajax_nopriv_aicp_save_lead', [__CLASS__, 'handle_save_lead']);
+        add_action('wp_ajax_aicp_capture_lead', [__CLASS__, 'handle_capture_lead']);
+        add_action('wp_ajax_nopriv_aicp_capture_lead', [__CLASS__, 'handle_capture_lead']);
     }
 
     private static function get_active_assistant() {


### PR DESCRIPTION
## Summary
- add lead capture button rendering and display logic in chatbot frontend
- implement manual lead capture request via AJAX and option to dismiss buttons
- register `aicp_capture_lead` AJAX hooks in frontend loader

## Testing
- `composer install` *(failed: CONNECT tunnel failed, response 403)*
- `vendor/bin/phpunit` *(failed: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68a4cae9a22c8330a2666d7bcc263161